### PR TITLE
Add PHP-8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/oscarotero/php-cs-fixer-config/issues"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "friendsofphp/php-cs-fixer": "^2.15"
     },
     "autoload": {


### PR DESCRIPTION
# Changed log

- Adding the `php-8.0` version support to fix following error message:

```
Run composer install --prefer-dist --no-progress --no-suggest
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
No lock file found. Updating dependencies instead of installing from lock file. Use composer update over composer install if you do not have a lock file.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - oscarotero/php-cs-fixer-config[v1.0.0, ..., v1.0.1] require php ^7.2 -> your php version (8.0.0) does not satisfy that requirement.
    - Root composer.json requires oscarotero/php-cs-fixer-config ^1.0 -> satisfiable by oscarotero/php-cs-fixer-config[v1.0.0, v1.0.1].

Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - oscarotero/php-cs-fixer-config[v1.0.0, ..., v1.0.1] require php ^7.2 -> your php version (8.0.0) does not satisfy that requirement.
    - Root composer.json requires oscarotero/php-cs-fixer-config ^1.0 -> satisfiable by oscarotero/php-cs-fixer-config[v1.0.0, v1.0.1].

Error: Process completed with exit code 2.
```

It presents on this [failed GitHub Action step](https://github.com/middlewares/access-log/runs/1603120999?check_suite_focus=true).